### PR TITLE
Canonicalize all paths passed to x-require

### DIFF
--- a/src/inline-html.js
+++ b/src/inline-html.js
@@ -2,6 +2,7 @@
 
 import CompileCache from 'electron-compile-cache';
 import cheerio from 'cheerio';
+import path from 'path';
 
 const extensions = ['html', 'htm'];
 
@@ -50,6 +51,22 @@ export default class InlineHtmlCompiler extends CompileCache {
       
       $(el).text(this.innerCompile($(el).text(), path));
       $(el).attr('type', 'application/javascript');
+    });
+    
+    $('x-require').map((i, el) => {
+      let src = $(el).attr('src');
+      
+      // File URL? Bail
+      if (src.match(/^file:/i)) return;
+      
+      // Absolute path? Bail.
+      if (src.match(/^([\/]|[A-Za-z]:)/i)) return;
+      
+      try {
+        $(el).attr('src', path.resolve(path.dirname(filePath), src));
+      } catch (e) {
+        $(el).text(`${e.message}\n${e.stack}`);
+      }
     });
     
     return $.html();

--- a/src/inline-html.js
+++ b/src/inline-html.js
@@ -48,7 +48,7 @@ export default class InlineHtmlCompiler extends CompileCache {
       let mimeType = $(el).attr('type');
       let path = `${filePath}:inline_${i}.${this.getExtensionFromMimeType(mimeType, 'script')}`;
       
-      $(el).text("\n" + this.innerCompile($(el).text(), path) + "\n");
+      $(el).text(this.innerCompile($(el).text(), path));
       $(el).attr('type', 'application/javascript');
     });
     


### PR DESCRIPTION
This PR works alongside the PR added to electron-compile to take any relative
paths found on the 'src' attribute of an x-require tag, and make that path
relative to the parent's page.

This means that when you attempt to include files that are inside an HTML
Import (i.e. a Polymer component), require paths will be relative to that HTML
file and not relative to the hosting index page.
