### PR TITLE
Add text/coffeescript for atom highlighting

### DIFF
--- a/src/inline-html.js
+++ b/src/inline-html.js
@@ -10,7 +10,10 @@ const mimeTypeToExtension = {
   'text/less': 'less',
   'application/javascript': 'js',
   'application/coffeescript': 'coffee',
-  'application/typescript': 'ts'
+  'application/typescript': 'ts',
+  'text/javascript': 'js',
+  'text/coffeescript': 'coffee',
+  'text/typescript': 'ts'
 };
 
 export default class InlineHtmlCompiler extends CompileCache {


### PR DESCRIPTION
And the other two script types too for good measure. Atom only highlights inline coffeescript correctly if the type is text/coffeescript and since I can't seem find the place to fix that within atom, I'm changing it here.

Merge this if you think others will benefit from it too, otherwise I'll simply use my forked version.
