### PR TITLE
Remove call to deleted scss module

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Compiler implementations for electron-compile",
   "main": "lib/main.js",
   "scripts": {
-    "compile": "babel --stage 0 -d lib/ src/",
+    "compile": "git clean -xdf lib && babel --stage 0 -d lib/ src/",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,6 @@ import _ from 'lodash';
 
 const filenames = [
   'css/less',
-  'css/scss',
   'js/babel',
   'js/coffeescript',
   'js/typescript',


### PR DESCRIPTION
The module has been deleted in src, but was still published in the lib folder (presumably just never cleaned). I removed the call to it, and added the cleaning functionality via a call to `git -xdf lib`. 
