### PR TITLE
Restrict parsing of script tags to unspecified or known MIME types

### DIFF
--- a/src/inline-html.js
+++ b/src/inline-html.js
@@ -52,7 +52,7 @@ export default class InlineHtmlCompiler extends CompileCache {
       $(el).attr('type', 'text/css');
     });
     
-    $('script').map((i, el) => {
+    $('script[text="type/javascript"], script:not([type])').map((i, el) => {
       let src = $(el).attr('src');
       if (src && src.length > 2) {
         $(el).attr('src', this.fixupRelativeUrl(src));


### PR DESCRIPTION
Using a more specific cheerio selector to look for script tags with `type="text/javascript"` or no type specified. Tested and working with handlebars!
