### PR TITLE
Add support for Sass/SCSS and CJSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-compilers",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "Compiler implementations for electron-compile",
   "main": "lib/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lodash": "^3.10.1",
     "mkdirp": "^0.5.1",
     "ncp": "^2.0.0",
+    "node-sass": "^3.4.2",
     "rimraf": "^2.4.3",
     "typescript-simple": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-preset-es2015": "^6.1.2",
     "btoa": "^1.1.2",
     "cheerio": "^0.19.0",
+    "coffee-react-transform": "^3.3.0",
     "coffee-script": "^1.10.0",
     "debug": "^2.2.0",
     "jade": "^1.11.0",

--- a/src/css/sass.js
+++ b/src/css/sass.js
@@ -1,0 +1,60 @@
+import _ from 'lodash';
+import path from 'path';
+import {SimpleCompilerBase} from '../compiler-base';
+
+const mimeTypes = ['text/sass', 'text/x-sass'];
+let sass = null;
+
+/**
+ * @access private
+ */
+export default class SassCompiler extends SimpleCompilerBase {
+  constructor() {
+    super();
+    this.compilerOptions.sourceMap = true;
+    this.seenFilePaths = {};
+  }
+
+  static getInputMimeTypes() {
+    return mimeTypes;
+  }
+
+  shouldCompileFileSync(fileName, compilerContext) {
+    return true;
+  }
+
+  determineDependentFilesSync(sourceCode, filePath, compilerContext) {
+    return [];
+  }
+
+  compileSync(sourceCode, filePath, compilerContext) {
+    sass = sass || require('node-sass');
+
+    let paths = Object.keys(this.seenFilePaths);
+    paths.unshift('.');
+
+    this.seenFilePaths[path.dirname(filePath)] = true;
+
+    let opts = _.extend({}, this.compilerOptions, {
+      indentedSyntax: true,
+      includePaths: paths,
+      file: path.basename(filePath),
+      data: sourceCode
+    });
+
+    let result = sass.renderSync(opts);
+
+    if (!result) {
+      throw result;
+    }
+
+    return {
+      code: result.css,
+      mimeType: 'text/css'
+    };
+  }
+
+  getCompilerVersion() {
+    return require('node-sass/package.json').version;
+  }
+}

--- a/src/css/scss.js
+++ b/src/css/scss.js
@@ -1,0 +1,59 @@
+import _ from 'lodash';
+import path from 'path';
+import {SimpleCompilerBase} from '../compiler-base';
+
+const mimeTypes = ['text/scss', 'text/x-scss'];
+let scss = null;
+
+/**
+ * @access private
+ */
+export default class ScssCompiler extends SimpleCompilerBase {
+  constructor() {
+    super();
+    this.compilerOptions.sourceMap = true;
+    this.seenFilePaths = {};
+  }
+
+  static getInputMimeTypes() {
+    return mimeTypes;
+  }
+
+  shouldCompileFileSync(fileName, compilerContext) {
+    return true;
+  }
+
+  determineDependentFilesSync(sourceCode, filePath, compilerContext) {
+    return [];
+  }
+
+  compileSync(sourceCode, filePath, compilerContext) {
+    scss = scss || require('node-sass');
+
+    let paths = Object.keys(this.seenFilePaths);
+    paths.unshift('.');
+
+    this.seenFilePaths[path.dirname(filePath)] = true;
+
+    let opts = _.extend({}, this.compilerOptions, {
+      includePaths: paths,
+      file: path.basename(filePath),
+      data: sourceCode
+    });
+
+    let result = scss.renderSync(opts);
+
+    if (!result) {
+      throw result;
+    }
+
+    return {
+      code: result.css,
+      mimeType: 'text/css'
+    };
+  }
+
+  getCompilerVersion() {
+    return require('node-sass/package.json').version;
+  }
+}

--- a/src/js/coffeescript.js
+++ b/src/js/coffeescript.js
@@ -3,12 +3,13 @@ import path from 'path';
 import btoa from 'btoa';
 import {SimpleCompilerBase} from '../compiler-base';
 
-const inputMimeTypes = ['text/coffeescript'];
+const inputMimeTypes = ['text/cjsx', 'text/coffeescript'];
 let coffee = null;
+let cjsx = null;
 
 /**
  * @access private
- */ 
+ */
  export default class CoffeeScriptCompiler extends SimpleCompilerBase {
   constructor() {
     super();
@@ -21,9 +22,10 @@ let coffee = null;
 
   compileSync(sourceCode, filePath) {
     coffee = coffee || require('coffee-script');
+    cjsx = cjsx || require('coffee-react-transform');
 
     let {js, v3SourceMap} = coffee.compile(
-      sourceCode,
+      cjsx(sourceCode),
       _.extend({ filename: filePath }, this.compilerOptions));
 
     js = `${js}\n` +

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,8 @@ import _ from 'lodash';
 
 const filenames = [
   'css/less',
+  'css/sass',
+  'css/scss',
   'js/babel',
   'js/coffeescript',
   'js/typescript',


### PR DESCRIPTION
In addition to https://github.com/electronjs/electron-compile/pull/55, this pull request adds support for Sass and SCSS compilation via [node-sass](https://github.com/sass/node-sass); used like:

``` jade
-// Include via link tag
link(rel="stylesheet" type="text/sass" href="index.sass")

-// Or inline styles
style(type="text/scss").
  div {
    display: none;

    a {
      display: block;
    }
  }

style(type="text/sass").
  div
    display: none

    section
      prop: val
```

As well as support for inline CJSX via [coffee-react-transform](https://github.com/jsdf/coffee-react-transform); used like:

``` coffee
Car = React.createClass
  render: ->
    <Vehicle doors={4} locked={isLocked()} data-colour="red" on>
      <Parts.FrontSeat />
      <Parts.BackSeat />
      <p className="seat">Which seat can I take? {@props?.seat or 'none'}</p>
      {# also, this is a comment }
    </Vehicle>
```

Also via inline script tag:

``` jade
script(type="text/cjsx").
  render: -> <div {... this.props}>hello</div>
```

Let me know if you'd like me to break these up. I've tested them locally via `npm link` and they seem to work perfectly. Thanks!
