### PR TITLE
less: push paths array specified in .compilerc

### DIFF
--- a/src/css/less.js
+++ b/src/css/less.js
@@ -39,6 +39,10 @@ export default class LessCompiler extends CompilerBase {
 
     this.seenFilePaths[path.dirname(filePath)] = true;
 
+    if (this.compilerOptions.paths) {
+      Array.prototype.push.apply(paths, this.compilerOptions.paths);
+    }
+
     let opts = _.extend({}, this.compilerOptions, {
       paths: paths,
       filename: path.basename(filePath)

--- a/src/css/less.js
+++ b/src/css/less.js
@@ -40,7 +40,7 @@ export default class LessCompiler extends CompilerBase {
     this.seenFilePaths[path.dirname(filePath)] = true;
 
     if (this.compilerOptions.paths) {
-      Array.prototype.push.apply(paths, this.compilerOptions.paths);
+      paths.push(...this.compilerOptions.paths);
     }
 
     let opts = _.extend({}, this.compilerOptions, {


### PR DESCRIPTION
This is similar to #3 which fixed scss includePath.

Example: my .compilerc contains

```
{
  "text/less": {
    "dumpLineNumbers": "comments",
    "paths": [
      "node_modules/font-awesome/less",
      "node_modules/bootstrap/less"
      ]
  }
}
```

Without this change:

```
electron-compile:config-parser Setting options for text/less: {"dumpLineNumbers":"comments","paths":["node_modules/font-awesome/less","node_modules/bootstrap/less"]}
electron-compile:compiler-host Compiling /Users/kangas/workspace/compass/src/index.less
electron-compile:compiler-host Using compiler options: {"dumpLineNumbers":"comments","paths":["node_modules/font-awesome/less","node_modules/bootstrap/less"]}
electron-compile:protocol-hook Failed to compile /Users/kangas/workspace/compass/src/index.less: 'font-awesome.less' wasn't found. Tried - styles/font-awesome.less,font-awesome.less
```

With this change, it works.

```
electron-compile:compile-cache Cache miss: saving out info for /Users/kangas/workspace/compass/src/index.less
```
