### PR TITLE
Pin Babel to v6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,30 +22,30 @@
   },
   "homepage": "https://github.com/paulcbetts/electron-compilers",
   "dependencies": {
-    "babel-core": "^6.1.2",
-    "babel-preset-es2015": "^6.1.2",
+    "babel-core": "~6.5.0",
+    "babel-preset-es2015": "~6.5.0",
     "btoa": "^1.1.2",
-    "cheerio": "^0.19.0",
+    "cheerio": "^0.20.0",
     "coffee-script": "^1.10.0",
     "cson": "^3.0.2",
     "debug": "^2.2.0",
     "jade": "^1.11.0",
-    "less": "^2.5.3",
+    "less": "^2.6.0",
     "lodash": "^3.10.1",
-    "mime-types": "^2.1.9",
+    "mime-types": "^2.1.10",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.4.3",
     "typescript-simple": "^2.0.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.1.2",
-    "babel-eslint": "^4.1.3",
-    "babel-preset-es2015": "^6.1.2",
-    "babel-preset-react": "^6.1.2",
-    "babel-preset-stage-0": "^6.1.2",
-    "esdoc": "^0.4.3",
+    "babel-cli": "~6.5.0",
+    "babel-eslint": "^5.0.0",
+    "babel-preset-es2015": "~6.5.0",
+    "babel-preset-react": "~6.5.0",
+    "babel-preset-stage-0": "~6.5.0",
+    "esdoc": "^0.4.5",
     "esdoc-es7-plugin": "0.0.3",
     "esdoc-plugin-async-to-sync": "^0.5.0",
-    "eslint": "^1.5.1"
+    "eslint": "^2.2.0"
   }
 }


### PR DESCRIPTION
This PR works around const+async/await being broken in Babel 6.6 (and in general, makes us more conservative with regards to Babel upgrades)
