### PR TITLE
Update HTML compiler to use Pug

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "coffee-script": "^1.10.0",
     "cson": "^3.0.2",
     "debug": "^2.2.0",
-    "jade": "^1.11.0",
+    "pug": "^2.0.0-alpha6",
     "less": "^2.5.3",
     "lodash": "^3.10.1",
     "@paulcbetts/mime-types": "^2.1.9",

--- a/src/html/jade.js
+++ b/src/html/jade.js
@@ -18,7 +18,7 @@ export default class JadeCompiler extends SimpleCompilerBase {
   }
 
   compileSync(sourceCode, filePath) {
-    jade = jade || require('jade');
+    jade = pug || require('pug');
 
     let code = jade.render(
       sourceCode,
@@ -28,6 +28,6 @@ export default class JadeCompiler extends SimpleCompilerBase {
   }
   
   getCompilerVersion() {
-    return require('jade/package.json').version;
+    return require('pug/package.json').version;
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ const filenames = [
   'json/cson',
   'html/inline-html',
   'html/jade',
+  'html/pug',
   'passthrough'
 ];
 


### PR DESCRIPTION
The update will allow the compiler to use Pug to compile and render .jade and .pug files.

I'm not sure if I've done it correctly, as I couldn't find a way to test the changes. I think that a PR will be required to reflect these changes on [electron-compile](https://github.com/electron/electron-compile).
