### PR TITLE
update typescript-simple version and add option to avoid semantic check

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@paulcbetts/mime-types": "^2.1.9",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.4.3",
-    "typescript-simple": "^2.0.0"
+    "typescript-simple": "^5.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.1.2",

--- a/src/html/inline-html.js
+++ b/src/html/inline-html.js
@@ -91,7 +91,9 @@ export default class InlineHtmlCompiler extends CompilerBase {
 
   async compile(sourceCode, filePath, compilerContext) {
     cheerio = cheerio || require('cheerio');
-    let $ = cheerio.load(sourceCode);
+    
+    //Leave the attributes casing as it is, because of Angular 2 and maybe other case-sensitive frameworks
+    let $ = cheerio.load(sourceCode, {lowerCaseAttributeNames: false});
     let toWait = [];
 
     let that = this;
@@ -175,7 +177,9 @@ export default class InlineHtmlCompiler extends CompilerBase {
 
   compileSync(sourceCode, filePath, compilerContext) {
     cheerio = cheerio || require('cheerio');
-    let $ = cheerio.load(sourceCode);
+    
+    //Leave the attributes casing as it is, because of Angular 2 and maybe other case-sensitive frameworks
+    let $ = cheerio.load(sourceCode, {lowerCaseAttributeNames: false});
 
     let that = this;
     let styleCount = 0;

--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -26,7 +26,7 @@ export default class TypeScriptCompiler extends SimpleCompilerBase {
     tss = tss || require('typescript-simple');
     
     // NB: Work around TypeScriptSimple modifying the options object
-    let compiler = new tss.TypeScriptSimple(_.assign({}, this.compilerOptions));
+    let compiler = new tss.TypeScriptSimple(_.assign({}, this.compilerOptions), this.compilerOptions.doSemanticChecks);
 
     return {
       code: compiler.compile(sourceCode, filePath),


### PR DESCRIPTION
The main change is that adds support for the doSemanticChecks option in typescript-simple. I have used the typescript options object to put this, but could be changed.

Another thing is to update TypeScript to use 1.8, i don't know if this could create a lot of incompatibilities, maybe this will require a mayor release.
