### PR TITLE
Do not force override TypeScript outDir

### DIFF
--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -7,11 +7,11 @@ let ts = null;
 
 /**
  * @access private
- */ 
+ */
 export default class TypeScriptCompiler extends SimpleCompilerBase {
   constructor() {
     super();
-    
+
     this.compilerOptions = {
       module: 'commonjs',
       sourceMap: true,
@@ -24,22 +24,21 @@ export default class TypeScriptCompiler extends SimpleCompilerBase {
   }
 
   compileSync(sourceCode, filePath) {
-    tss = tss || require('@paulcbetts/typescript-simple'); 
+    tss = tss || require('@paulcbetts/typescript-simple');
     ts = ts || require('typescript');
-    
-    // NB: We set outDir here to work around a bug in TypeScriptSimple
+
     // NB: If you enable semantic checks with TSX, you're gonna have a
     //     Bad Time
-    let extraOpts = {target: ts.ScriptTarget.ES6, outDir: '/'};
+    let extraOpts = {target: ts.ScriptTarget.ES6};
     let isJsx = false;
     if (filePath.match(/\.tsx$/i)) {
       extraOpts.jsx = ts.JsxEmit.React;
       isJsx = true;
     }
-    
+
     // NB: Work around TypeScriptSimple modifying the options object
     let compiler = new tss.TypeScriptSimple(
-      Object.assign({}, this.compilerOptions, extraOpts), 
+      Object.assign({}, this.compilerOptions, extraOpts),
       this.compilerOptions.doSemanticChecks && !isJsx);
 
     return {


### PR DESCRIPTION
This PR removes force override to `outDir` of TypeScript compiler options to allow correct compilation emit for relative reference to internal modules.

Let's say folder structures 

``` js
--app
    |--src
         |--utils
         |    +app-id.ts
         +logger.ts
```

and `app-id.ts` refer internal module `logger` as

``` js
import {logger} from '../logger';

logger.doSomething();
```

Then TypeScript compiler calculates output path unexpectedly, like

```
/logger.js
/app/app-id.js
```

makes typescript-simple fails to lookup emitted output. I don't have concrete explanation why path resolving works in those way though.
