### PR TITLE
Replace node-sass with sass.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "@paulcbetts/mime-types": "^2.1.10",
-    "@paulcbetts/node-sass": "4.1.1",
     "@paulcbetts/typescript-simple": "^6.0.0",
     "@paulcbetts/vueify": "9.4.3",
     "babel-core": "^6.13.2",
@@ -41,6 +40,7 @@
     "mkdirp": "^0.5.1",
     "nib": "^1.1.2",
     "rimraf": "^2.5.4",
+    "sass.js": "^0.10.1",
     "stylus": "^0.54.5",
     "toutsuite": "^0.5.0",
     "typescript": "~2.1.4"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^2.5.4",
     "sass.js": "^0.10.1",
     "stylus": "^0.54.5",
-    "toutsuite": "^0.5.0",
+    "toutsuite": "^0.6.0",
     "typescript": "~2.1.4"
   },
   "devDependencies": {

--- a/src/css/sass.js
+++ b/src/css/sass.js
@@ -14,7 +14,7 @@ export default class SassCompiler extends CompilerBase {
     super();
 
     this.compilerOptions = {
-      sourceComments: true,
+      comments: true,
       sourceMapEmbed: true,
       sourceMapContents: true
     };
@@ -49,11 +49,8 @@ export default class SassCompiler extends CompilerBase {
     paths.unshift('.');
 
     let opts = Object.assign({}, this.compilerOptions, {
-      data: sourceCode,
       indentedSyntax: filePath.match(/\.sass$/i),
       sourceMapRoot: filePath,		
-      includePaths: paths,
-      filename: path.basename(filePath)
     });
 
     let result = await new Promise((res,rej) => {
@@ -97,11 +94,8 @@ export default class SassCompiler extends CompilerBase {
     paths.unshift('.');
 
     let opts = Object.assign({}, this.compilerOptions, {
-      data: sourceCode,
       indentedSyntax: filePath.match(/\.sass$/i),
       sourceMapRoot: filePath,		
-      includePaths: paths,
-      filename: path.basename(filePath)
     });
 
     let result;


### PR DESCRIPTION
This kind of works not really, but native modules are super problematic with electron-compile because they have to be somehow both simultaneously compiled for the current Electron as well as system node.js (for build systems). Replace it with sass.js, which is not as good but seems to kind of work maybe.