### PR TITLE
Bump up package dependencies to support latest TS compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "stylus": "^0.54.5",
     "toutsuite": "^0.6.0",
     "typescript": "~2.1.4",
-    "typescript-simple": "^6.0.0"
+    "typescript-simple": "^7.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",


### PR DESCRIPTION
This PR bumps up `typescript-simple` to support latest TS compiler instead of pinned `2.0.x` in `tss@6` version.

![image](https://cloud.githubusercontent.com/assets/1210596/21699969/e78081e4-d352-11e6-890c-9f384d86dd1b.png)
