### PR TITLE
feat(TypeScriptCompiler): utilize ts compiler api directly instead of 3rd party module

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,10 @@
     "rimraf": "^2.5.4",
     "sass.js": "^0.10.1",
     "stylus": "^0.54.5",
-    "toutsuite": "^0.6.0",
-    "typescript": "~2.1.4",
-    "typescript-simple": "^7.0.2"
+    "toutsuite": "^0.6.0"
+  },
+  "peerDependencies": {
+    "typescript": ">=1.6"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",


### PR DESCRIPTION
This PR introduced change to `TypeScriptCompiler` implementation, no longer rely on 3rd party compiler wrapper (`typescript-simple`) instead directly consume TypeScript compiler api.

This change is *BREAKING* change for several reasons,

- now TypeScript compiler is `peerDependencies`, have minimum requirement of `>=1.6` to support latest breaking compiler api surface.
- now `electron-compiler`s no longer automatically mutate some of compiler options based on context, strictly consume user configuration object as-is. Means, if user accidentally unspecified / incorrectly specified some of configs (like not setting `react` for tsx), user will experience compilation failure since `TypeScriptCompiler` impl no logner touches it.