### PR TITLE
Throw compiler option parse error correctly

### DIFF
--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -29,7 +29,7 @@ export default class TypeScriptCompiler extends SimpleCompilerBase {
     if (!parsedConfig) {
       const results = tsCompiler.convertCompilerOptionsFromJson(this.compilerOptions);
       if (results.errors && results.errors.length) {
-        throw new Error(results.errors);
+        throw new Error(JSON.stringify(results.errors));
       }
       parsedConfig = this.parsedConfig = results.options;
     }


### PR DESCRIPTION
Sorry for always forgetting `stringify`. This PR correctly displays parse config error instead of blind `[object Object]`.