### PR TITLE
fix(TypeScriptCompiler): do not process compiler if not exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,7 @@
     "rimraf": "^2.5.4",
     "sass.js": "^0.10.1",
     "stylus": "^0.54.5",
-    "toutsuite": "^0.6.0"
-  },
-  "peerDependencies": {
+    "toutsuite": "^0.6.0",
     "typescript": ">=1.6"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR adds handlings to avoid compiler fails if TypeScript did not installed for any cases. And also revert compiler dependency to `dependency` instead of peerDep which makes compiler optional, to avoid regressions in #52.

- closes #52.