### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+- '5'
+- '6'
+- '7'
+
+script:
+- npm run lint
+- npm run compile

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "doc": "esdoc -c ./esdoc.json",
     "compile": "git clean -xdf lib && babel -d lib/ src/",
+    "lint": "eslint src",
     "prepublish": "npm run compile"
   },
   "repository": {

--- a/src/compiler-base.js
+++ b/src/compiler-base.js
@@ -1,17 +1,17 @@
 /**
- * This class is the base interface for compilers that are used by 
- * electron-compile. If your compiler library only supports a 
+ * This class is the base interface for compilers that are used by
+ * electron-compile. If your compiler library only supports a
  * synchronous API, use SimpleCompilerBase instead.
  *
  * @interface
- */ 
+ */
 export class CompilerBase {
   constructor() {
     this.compilerOptions = {};
   }
-  
-  /**  
-   * This method describes the MIME types that your compiler supports as input. 
+
+  /**
+   * This method describes the MIME types that your compiler supports as input.
    * Many precompiled file types don't have a specific MIME type, so if it's not
    * recognized by the mime-types package, you need to patch rig-mime-types in
    * electron-compile.
@@ -19,7 +19,7 @@ export class CompilerBase {
    * @return {string[]}  An array of MIME types that this compiler can compile.
    *
    * @abstract
-   */   
+   */
   static getInputMimeTypes() {
     throw new Error("Implement me!");
   }
@@ -27,7 +27,7 @@ export class CompilerBase {
 
   /**
    * Determines whether a file should be compiled
-   *    
+   *
    * @param  {string} fileName        The full path of a file to compile.
    * @param  {object} compilerContext An object that compilers can add extra
                                     information to as part of a job - the caller
@@ -35,36 +35,36 @@ export class CompilerBase {
    * @return {Promise<bool>}        True if you are able to compile this file.
    *
    * @abstract
-   */   
-  async shouldCompileFile(fileName, compilerContext) {
+   */
+  async shouldCompileFile(fileName, compilerContext) { // eslint-disable-line no-unused-vars
     throw new Error("Implement me!");
   }
 
-  
-  /**  
+
+  /**
    * Returns the dependent files of this file. This is used for languages such
    * as LESS which allow you to import / reference other related files. In future
    * versions of electron-compile, we will use this information to invalidate
    * all of the parent files if a child file changes.
-   *    
+   *
    * @param  {string} sourceCode    The contents of filePath
    * @param  {string} fileName        The full path of a file to compile.
    * @param  {object} compilerContext An object that compilers can add extra
                                     information to as part of a job - the caller
                                     won't do anything with this.
    * @return {Promise<string[]>}    An array of dependent file paths, or an empty
-   *                                array if there are no dependent files. 
+   *                                array if there are no dependent files.
    *
    * @abstract
-   */   
-  async determineDependentFiles(sourceCode, fileName, compilerContext) {
+   */
+  async determineDependentFiles(sourceCode, fileName, compilerContext) { // eslint-disable-line no-unused-vars
     throw new Error("Implement me!");
   }
 
-  
-  /**  
+
+  /**
    * Compiles the file
-   *    
+   *
    * @param  {string} sourceCode    The contents of filePath
    * @param  {string} fileName      The full path of a file to compile.
    * @param  {object} compilerContext An object that compilers can add extra
@@ -72,38 +72,38 @@ export class CompilerBase {
                                     won't do anything with this.
    * @return {Promise<object>}      An object representing the compiled result
    * @property {string} code        The compiled code
-   * @property {string} mimeType    The MIME type of the compiled result, which 
+   * @property {string} mimeType    The MIME type of the compiled result, which
    *                                should exist in the mime-types database.
    *
    * @abstract
-   */   
-  async compile(sourceCode, fileName, compilerContext) {
+   */
+  async compile(sourceCode, fileName, compilerContext) { // eslint-disable-line no-unused-vars
     throw new Error("Implement me!");
   }
 
-  shouldCompileFileSync(fileName, compilerContext) {
+  shouldCompileFileSync(fileName, compilerContext) { // eslint-disable-line no-unused-vars
     throw new Error("Implement me!");
   }
 
-  determineDependentFilesSync(sourceCode, fileName, compilerContext) {
+  determineDependentFilesSync(sourceCode, fileName, compilerContext) { // eslint-disable-line no-unused-vars
     throw new Error("Implement me!");
   }
 
-  compileSync(sourceCode, fileName, compilerContext) {
+  compileSync(sourceCode, fileName, compilerContext) { // eslint-disable-line no-unused-vars
     throw new Error("Implement me!");
   }
 
   /**
-   * Returns a version number representing the version of the underlying 
+   * Returns a version number representing the version of the underlying
    * compiler library. When this number changes, electron-compile knows
    * to throw all away its generated code.
-   *    
-   * @return {string}  A version number. Note that this string isn't 
+   *
+   * @return {string}  A version number. Note that this string isn't
    *                   parsed in any way, just compared to the previous
    *                   one for equality.
    *
    * @abstract
-   */   
+   */
   getCompilerVersion() {
     throw new Error("Implement me!");
   }
@@ -111,25 +111,25 @@ export class CompilerBase {
 
 
 /**
- * This class implements all of the async methods of CompilerBase by just 
- * calling the sync version. Use it to save some time when implementing 
+ * This class implements all of the async methods of CompilerBase by just
+ * calling the sync version. Use it to save some time when implementing
  * simple compilers.
  *
- * To use it, implement the compile method, the getCompilerVersion method, 
- * and the getInputMimeTypes static method. 
- * 
+ * To use it, implement the compile method, the getCompilerVersion method,
+ * and the getInputMimeTypes static method.
+ *
  * @abstract
- */ 
+ */
 export class SimpleCompilerBase extends CompilerBase {
   constructor() {
     super();
   }
 
-  async shouldCompileFile(fileName, compilerContext) {
+  async shouldCompileFile(fileName, compilerContext) { // eslint-disable-line no-unused-vars
     return true;
   }
 
-  async determineDependentFiles(sourceCode, filePath, compilerContext) {
+  async determineDependentFiles(sourceCode, filePath, compilerContext) { // eslint-disable-line no-unused-vars
     return [];
   }
 
@@ -137,11 +137,11 @@ export class SimpleCompilerBase extends CompilerBase {
     return this.compileSync(sourceCode, filePath, compilerContext);
   }
 
-  shouldCompileFileSync(fileName, compilerContext) {
+  shouldCompileFileSync(fileName, compilerContext) { // eslint-disable-line no-unused-vars
     return true;
   }
 
-  determineDependentFilesSync(sourceCode, filePath, compilerContext) {
+  determineDependentFilesSync(sourceCode, filePath, compilerContext) { // eslint-disable-line no-unused-vars
     return [];
   }
 }

--- a/src/css/less.js
+++ b/src/css/less.js
@@ -24,7 +24,7 @@ export default class LessCompiler extends CompilerBase {
     return mimeTypes;
   }
 
-  async shouldCompileFile(fileName, compilerContext) {
+  async shouldCompileFile(fileName, compilerContext) { // eslint-disable-line no-unused-vars
     return true;
   }
 
@@ -32,7 +32,7 @@ export default class LessCompiler extends CompilerBase {
     return this.determineDependentFilesSync(sourceCode, filePath, compilerContext);
   }
 
-  async compile(sourceCode, filePath, compilerContext) {
+  async compile(sourceCode, filePath, compilerContext) { // eslint-disable-line no-unused-vars
     lessjs = lessjs || this.getLess();
 
     let thisPath = path.dirname(filePath);
@@ -66,11 +66,11 @@ export default class LessCompiler extends CompilerBase {
     };
   }
 
-  shouldCompileFileSync(fileName, compilerContext) {
+  shouldCompileFileSync(fileName, compilerContext) { // eslint-disable-line no-unused-vars
     return true;
   }
 
-  determineDependentFilesSync(sourceCode, filePath, compilerContext) {
+  determineDependentFilesSync(sourceCode, filePath, compilerContext) { // eslint-disable-line no-unused-vars
     let dependencyFilenames = detective(sourceCode);
     let dependencies = [];
 
@@ -81,7 +81,7 @@ export default class LessCompiler extends CompilerBase {
     return dependencies;
   }
 
-  compileSync(sourceCode, filePath, compilerContext) {
+  compileSync(sourceCode, filePath, compilerContext) { // eslint-disable-line no-unused-vars
     lessjs = lessjs || this.getLess();
 
     let source;

--- a/src/css/sass.js
+++ b/src/css/sass.js
@@ -29,7 +29,7 @@ export default class SassCompiler extends CompilerBase {
     return mimeTypes;
   }
 
-  async shouldCompileFile(fileName, compilerContext) {
+  async shouldCompileFile(fileName, compilerContext) { // eslint-disable-line no-unused-vars
     return true;
   }
 
@@ -37,7 +37,7 @@ export default class SassCompiler extends CompilerBase {
     return this.determineDependentFilesSync(sourceCode, filePath, compilerContext);
   }
 
-  async compile(sourceCode, filePath, compilerContext) {
+  async compile(sourceCode, filePath, compilerContext) { // eslint-disable-line no-unused-vars
     sass = sass || this.getSass();
 
     let thisPath = path.dirname(filePath);
@@ -86,11 +86,11 @@ export default class SassCompiler extends CompilerBase {
     };
   }
 
-  shouldCompileFileSync(fileName, compilerContext) {
+  shouldCompileFileSync(fileName, compilerContext) { // eslint-disable-line no-unused-vars
     return true;
   }
 
-  determineDependentFilesSync(sourceCode, filePath, compilerContext) {
+  determineDependentFilesSync(sourceCode, filePath, compilerContext) { // eslint-disable-line no-unused-vars
     let dependencyFilenames = path.extname(filePath) === '.sass' ? detectiveSASS(sourceCode) : detectiveSCSS(sourceCode);
     let dependencies = [];
 
@@ -101,7 +101,7 @@ export default class SassCompiler extends CompilerBase {
     return dependencies;
   }
 
-  compileSync(sourceCode, filePath, compilerContext) {
+  compileSync(sourceCode, filePath, compilerContext) { // eslint-disable-line no-unused-vars
     sass = sass || this.getSass();
 
     let thisPath = path.dirname(filePath);

--- a/src/css/stylus.js
+++ b/src/css/stylus.js
@@ -34,15 +34,15 @@ export default class StylusCompiler extends CompilerBase {
     return mimeTypes;
   }
 
-  async shouldCompileFile(fileName, compilerContext) {
+  async shouldCompileFile(fileName, compilerContext) { // eslint-disable-line no-unused-vars
     return true;
   }
 
-  async determineDependentFiles(sourceCode, filePath, compilerContext) {
+  async determineDependentFiles(sourceCode, filePath, compilerContext) { // eslint-disable-line no-unused-vars
     return this.determineDependentFilesSync(sourceCode, filePath, compilerContext);
   }
 
-  async compile(sourceCode, filePath, compilerContext) {
+  async compile(sourceCode, filePath, compilerContext) { // eslint-disable-line no-unused-vars
     nib = nib || require('nib');
     stylusjs = stylusjs || require('stylus');
     this.seenFilePaths[path.dirname(filePath)] = true;
@@ -89,8 +89,8 @@ export default class StylusCompiler extends CompilerBase {
 
     return opts;
   }
-  
-  
+
+
   applyOpts(opts, stylus) {
     each(opts, (val, key) => {
       switch(key) {
@@ -109,11 +109,11 @@ export default class StylusCompiler extends CompilerBase {
     stylus.set('paths', Object.keys(this.seenFilePaths).concat(['.']));
   }
 
-  shouldCompileFileSync(fileName, compilerContext) {
+  shouldCompileFileSync(fileName, compilerContext) { // eslint-disable-line no-unused-vars
     return true;
   }
 
-  determineDependentFilesSync(sourceCode, filePath, compilerContext) {
+  determineDependentFilesSync(sourceCode, filePath, compilerContext) { // eslint-disable-line no-unused-vars
     let dependencyFilenames = detective(sourceCode);
     let dependencies = [];
 
@@ -124,7 +124,7 @@ export default class StylusCompiler extends CompilerBase {
     return dependencies;
   }
 
-  compileSync(sourceCode, filePath, compilerContext) {
+  compileSync(sourceCode, filePath, compilerContext) { // eslint-disable-line no-unused-vars
     nib = nib || require('nib');
     stylusjs = stylusjs || require('stylus');
     this.seenFilePaths[path.dirname(filePath)] = true;

--- a/src/html/inline-html.js
+++ b/src/html/inline-html.js
@@ -65,11 +65,11 @@ export default class InlineHtmlCompiler extends CompilerBase {
     return inputMimeTypes;
   }
 
-  async shouldCompileFile(fileName, compilerContext) {
+  async shouldCompileFile(fileName, compilerContext) { // eslint-disable-line no-unused-vars
     return true;
   }
 
-  async determineDependentFiles(sourceCode, filePath, compilerContext) {
+  async determineDependentFiles(sourceCode, filePath, compilerContext) { // eslint-disable-line no-unused-vars
     return [];
   }
 
@@ -178,11 +178,11 @@ export default class InlineHtmlCompiler extends CompilerBase {
     };
   }
 
-  shouldCompileFileSync(fileName, compilerContext) {
+  shouldCompileFileSync(fileName, compilerContext) { // eslint-disable-line no-unused-vars
     return true;
   }
 
-  determineDependentFilesSync(sourceCode, filePath, compilerContext) {
+  determineDependentFilesSync(sourceCode, filePath, compilerContext) { // eslint-disable-line no-unused-vars
     return [];
   }
 

--- a/src/html/vue.js
+++ b/src/html/vue.js
@@ -4,8 +4,6 @@ import toutSuite from 'toutsuite';
 const inputMimeTypes = ['text/vue'];
 let vueify = null;
 
-const d = require('debug')('electron-compile:vue');
-
 const mimeTypeToSimpleType = {
   'text/coffeescript': 'coffee',
   'text/typescript': 'ts',
@@ -105,15 +103,15 @@ export default class VueCompiler extends CompilerBase {
     return inputMimeTypes;
   }
 
-  async shouldCompileFile(fileName, compilerContext) {
+  async shouldCompileFile(fileName, compilerContext) { // eslint-disable-line no-unused-vars
     return true;
   }
 
-  async determineDependentFiles(sourceCode, filePath, compilerContext) {
+  async determineDependentFiles(sourceCode, filePath, compilerContext) { // eslint-disable-line no-unused-vars
     return [];
   }
 
-  async compile(sourceCode, filePath, compilerContext) {
+  async compile(sourceCode, filePath, compilerContext) { // eslint-disable-line no-unused-vars
     vueify = vueify || require('@paulcbetts/vueify');
 
     let opts = Object.assign({}, this.compilerOptions);
@@ -130,15 +128,15 @@ export default class VueCompiler extends CompilerBase {
     };
   }
 
-  shouldCompileFileSync(fileName, compilerContext) {
+  shouldCompileFileSync(fileName, compilerContext) { // eslint-disable-line no-unused-vars
     return true;
   }
 
-  determineDependentFilesSync(sourceCode, filePath, compilerContext) {
+  determineDependentFilesSync(sourceCode, filePath, compilerContext) { // eslint-disable-line no-unused-vars
     return [];
   }
 
-  compileSync(sourceCode, filePath, compilerContext) {
+  compileSync(sourceCode, filePath, compilerContext) { // eslint-disable-line no-unused-vars
     vueify = vueify || require('@paulcbetts/vueify');
 
     let opts = Object.assign({}, this.compilerOptions);

--- a/src/js/babel.js
+++ b/src/js/babel.js
@@ -46,7 +46,7 @@ export default class BabelCompiler extends SimpleCompilerBase {
     return null;
   }
 
-  compileSync(sourceCode, filePath, compilerContext) {
+  compileSync(sourceCode, filePath, compilerContext) { // eslint-disable-line no-unused-vars
     babel = babel || require('babel-core');
 
     let opts = Object.assign({}, this.compilerOptions, {

--- a/src/json/cson.js
+++ b/src/json/cson.js
@@ -15,7 +15,7 @@ export default class CSONCompiler extends SimpleCompilerBase {
     return inputMimeTypes;
   }
 
-  compileSync(sourceCode, filePath) {
+  compileSync(sourceCode, filePath) { // eslint-disable-line no-unused-vars
     CSON = CSON || require('cson');
 
     let result = CSON.parse(sourceCode);


### PR DESCRIPTION
All it does is run `eslint` and `babel`. Also fixes a bunch of lint warnings.

Requires someone with the requisite privileges to enable the Travis CI integration.