### PR TITLE
feat(compilers): emit sourceMap object if available

### DIFF
--- a/src/js/babel.js
+++ b/src/js/babel.js
@@ -75,10 +75,19 @@ export default class BabelCompiler extends CompilerBase {
       let presets = this.attemptToPreload(opts.presets, 'preset');
       if (presets && presets.length === opts.presets.length) opts.presets = presets;
     }
+    const output = babel.transform(sourceCode, opts);
+    const sourceMapObject = output.map;
+
+    let sourceMaps;
+    if (sourceMapObject) {
+      sourceMapObject.sourcesContent && delete sourceMapObject.sourcesContent;
+      sourceMaps = JSON.stringify(sourceMapObject);
+    }
 
     return {
-      code: babel.transform(sourceCode, opts).code,
-      mimeType: 'application/javascript'
+      code: output.code,
+      mimeType: 'application/javascript',
+      sourceMaps
     };
   }
 

--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -49,9 +49,15 @@ export default class TypeScriptCompiler extends SimpleCompilerBase {
 
     d(output.diagnostics);
 
+    let sourceMaps;
+    if (output.sourceMapText) {
+      sourceMaps = output.sourceMapText;
+    }
+
     return {
       code: output.outputText,
-      mimeType: this.outMimeType
+      mimeType: this.outMimeType,
+      sourceMaps
     };
   }
 


### PR DESCRIPTION
This PR forwards source map object generated by compiler (for now `babel` and `TypeScript` only), into compile result object. This property will be filled if compiler option specifies to enable non-inline source map, someone who wants to have separate source map in some usecases (like production code, to uploade source map into telemetry / analytics to reconstruct mapped stack traces from release build).

Still, this change doesn't enable complete source map consumption since `electron-compile` doesn't utilize this property yet at this moment. This PR is ground work to make changes into `electron-compile`.