### PR TITLE
fix(compilers): preserve inline sources

### DIFF
--- a/src/js/babel.js
+++ b/src/js/babel.js
@@ -75,13 +75,7 @@ export default class BabelCompiler extends CompilerBase {
       if (presets && presets.length === opts.presets.length) opts.presets = presets;
     }
     const output = babel.transform(sourceCode, opts);
-    const sourceMapObject = output.map;
-
-    let sourceMaps;
-    if (sourceMapObject) {
-      sourceMapObject.sourcesContent && delete sourceMapObject.sourcesContent;
-      sourceMaps = JSON.stringify(sourceMapObject);
-    }
+    const sourceMaps = output.map ? JSON.stringify(output.map) : null;
 
     return {
       code: output.code,

--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -46,13 +46,9 @@ export default class TypeScriptCompiler extends SimpleCompilerBase {
     };
 
     const output = ts.transpileModule(sourceCode, transpileOptions);
+    const sourceMaps = output.sourceMapText ? output.sourceMapText : null;
 
     d(output.diagnostics);
-
-    let sourceMaps;
-    if (output.sourceMapText) {
-      sourceMaps = output.sourceMapText;
-    }
 
     return {
       code: output.outputText,


### PR DESCRIPTION
This PR fixes my fault to handle sourcemaps in `babel` compiler, which explicitly removed inline sources prevent construct sourcemap with inline sources even if user want to. Now both of compiler passthrough sourcemaps as generated by compiler.