### PR TITLE
Hot Module Reload for TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "detective-scss": "^1.0.0",
     "detective-stylus": "^1.0.0",
     "jade": "^1.11.0",
+    "js-string-escape": "^1.0.1",
     "less": "^2.7.1",
     "mkdirp": "^0.5.1",
     "nib": "^1.1.2",

--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -1,5 +1,6 @@
 import {SimpleCompilerBase} from '../compiler-base';
 import path from 'path';
+import jsEscape from 'js-string-escape';
 
 const inputMimeTypes = ['text/typescript', 'text/tsx'];
 const d = require('debug')('electron-compile:typescript-compiler');
@@ -40,21 +41,81 @@ export default class TypeScriptCompiler extends SimpleCompilerBase {
     ts = ts || require('typescript');
     const options = this._getParsedConfigOptions(ts);
 
+    const isTsx = filePath.match(/\.tsx$/i);
     const transpileOptions = {
       compilerOptions: options,
       fileName: filePath.match(/\.(ts|tsx)$/i) ? path.basename(filePath) : null
     };
 
+    if (isTsx) {
+      sourceCode = this.addHotModuleLoadingRegistration(sourceCode, filePath, this.getExportsForFile(filePath, options));
+    }
+
     const output = ts.transpileModule(sourceCode, transpileOptions);
     const sourceMaps = output.sourceMapText ? output.sourceMapText : null;
 
-    d(output.diagnostics);
+    d(JSON.stringify(output.diagnostics));
 
+    let sourceMaps;
+    if (output.sourceMapText) {
+      sourceMaps = output.sourceMapText;
+    }
+
+
+    console.log(output.outputText);
     return {
       code: output.outputText,
       mimeType: this.outMimeType,
       sourceMaps
     };
+  }
+
+  addHotModuleLoadingRegistration(sourceCode, fileName, exports) {
+    if (exports.length < 1) return sourceCode;
+
+    let registrations = exports.map(x => 
+      `__REACT_HOT_LOADER__.register(${x}, "${x}", __FILENAME__);\n`
+    );
+
+    let tmpl = `
+${sourceCode}
+
+if (__REACT_HOT_LOADER__) {
+  const __FILENAME__ = "${jsEscape(fileName)}";
+  ${registrations}
+}`;
+
+    return tmpl;
+  }
+
+  getExportsForFile(fileName, tsOptions) {
+    let pg = ts.createProgram([fileName], tsOptions);
+    let c = pg.getTypeChecker();
+    let ret = [];
+
+    // Walk the tree to search for classes
+    let visit = (node) => {
+      if (!this.isNodeExported(node)) return;
+      
+      if (node.kind === ts.SyntaxKind.ClassDeclaration || node.kind === ts.SyntaxKind.FunctionDeclaration) {
+        ret.push(c.getSymbolAtLocation(node.name).getName());
+      }
+    };
+
+    let filePathWithForwardSlashes = fileName.replace(/[\\]/g, '/');
+    for (const sourceFile of pg.getSourceFiles()) {
+      if (sourceFile.fileName !== filePathWithForwardSlashes) {
+        continue;
+      }
+      
+      ts.forEachChild(sourceFile, visit);
+    }
+
+    return ret;
+  }
+
+  isNodeExported(node) {
+    return (node.flags & ts.NodeFlags.Export) !== 0 || (node.parent && node.parent.kind === ts.SyntaxKind.SourceFile);
   }
 
   getCompilerVersion() {

--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -56,13 +56,6 @@ export default class TypeScriptCompiler extends SimpleCompilerBase {
 
     d(JSON.stringify(output.diagnostics));
 
-    let sourceMaps;
-    if (output.sourceMapText) {
-      sourceMaps = output.sourceMapText;
-    }
-
-
-    console.log(output.outputText);
     return {
       code: output.outputText,
       mimeType: this.outMimeType,


### PR DESCRIPTION
This PR does the equivalent of https://github.com/gaearon/react-hot-loader/tree/next/src/babel for TypeScript in tsx files, adding a call to register exported types with the hot module loader