### PR TITLE
creating a default name

### DIFF
--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -81,9 +81,11 @@ export default class TypeScriptCompiler extends SimpleCompilerBase {
   addHotModuleLoadingRegistration(sourceCode, fileName, exports) {
     if (exports.length < 1) return sourceCode;
 
-    let registrations = exports.map(x => 
-      `__REACT_HOT_LOADER__.register(${x}, "${x}", __FILENAME__);\n`
-    );
+    let registrations = exports.map(x => {
+      let id = `${x}` == 'default' ? "_default" : `${x}`
+      let name = `"${x}"`
+      return `__REACT_HOT_LOADER__.register(${id}, ${name}, __FILENAME__);\n`
+    });
 
     let tmpl = `
 ${sourceCode}

--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -62,7 +62,7 @@ export default class TypeScriptCompiler extends SimpleCompilerBase {
       fileName: filePath.match(/\.(ts|tsx)$/i) ? path.basename(filePath) : null
     };
 
-    if (isTsx && options.builtinOpts.hotModuleReload !== false) {
+    if (isTsx && options.builtinOpts.hotModuleReload === true) {
       sourceCode = this.addHotModuleLoadingRegistration(sourceCode, filePath, this.getExportsForFile(filePath, options.typescriptOpts));
     }
 


### PR DESCRIPTION
1. This will create a `_default` ID if the module has a default export 
2. This will addHotModuleLoadingRegistration only if `builtInOpts.hotModuleReload == true)
