### PR TITLE
Add optional Istanbul support

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "detective-sass": "^2.0.0",
     "detective-scss": "^1.0.0",
     "detective-stylus": "^1.0.0",
+    "istanbul": "^0.4.5",
     "jade": "^1.11.0",
     "js-string-escape": "^1.0.1",
     "less": "^2.7.1",


### PR DESCRIPTION
This allows you to set `coverage: true` in your TypeScript and Babel options, and get code instrumented by Istanbul. To get the coverage output, then add something like this to your test suite:

```js
after(() => {
  if (!('__coverage__' in window)) return;
  const { Reporter, Collector } = require('istanbul');

  const coll = new Collector();
  coll.add(window.__coverage__);

  const reporter = new Reporter(null, path.join(__dirname, '..', 'coverage'));
  reporter.addAll(['text-summary', 'lcovonly']);

  return new Promise((res) => {
    reporter.write(coll, false, res);
  });
});
```

This has an advantage in that it works with electron-mocha as well which is v cool. 