### PR TITLE
Use exports.default if _default is not defined, fixes #64 for typescript on es2017 target

### DIFF
--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -87,7 +87,7 @@ export default class TypeScriptCompiler extends SimpleCompilerBase {
     if (exports.length < 1) return sourceCode;
 
     let registrations = exports.map(x => {
-      let id = `${x}` == 'default' ? "_default" : `${x}`
+      let id = `${x}` == 'default' ? '(typeof _default !== \'undefined\' ? _default : exports.default)' : `${x}`
       let name = `"${x}"`
       return `__REACT_HOT_LOADER__.register(${id}, ${name}, __FILENAME__);\n`
     });

--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -86,9 +86,11 @@ export default class TypeScriptCompiler extends SimpleCompilerBase {
   addHotModuleLoadingRegistration(sourceCode, fileName, exports) {
     if (exports.length < 1) return sourceCode;
 
-    let registrations = exports.map(x => 
-      `__REACT_HOT_LOADER__.register(${x}, "${x}", __FILENAME__);\n`
-    );
+    let registrations = exports.map(x => {
+      let id = `${x}` == 'default' ? "_default" : `${x}`
+      let name = `"${x}"`
+      return `__REACT_HOT_LOADER__.register(${id}, ${name}, __FILENAME__);\n`
+    });
 
     let tmpl = `
 ${sourceCode}


### PR DESCRIPTION
cf. [this comment](https://github.com/electron/electron-compilers/pull/64#discussion_r113245117)

I feel bad about this, #64 was merged after I confirmed it worked for me when in fact.. I was probably misled by the cache? Sorry about that 😞 

(Note that this will break if you manually define a variable named `_default` that isn't your default export but that's just the price to pay for babel compat I suppose?)