### PR TITLE
TypeScript: faster getExportsForFile

### DIFF
--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -87,7 +87,7 @@ export default class TypeScriptCompiler extends SimpleCompilerBase {
     if (exports.length < 1) return sourceCode;
 
     let registrations = exports.map(x => {
-      let id = `${x}` == 'default' ? "_default" : `${x}`
+      let id = `${x}` == 'default' ? '(typeof _default !== \'undefined\' ? _default : exports.default)' : `${x}`
       let name = `"${x}"`
       return `__REACT_HOT_LOADER__.register(${id}, ${name}, __FILENAME__);\n`
     });

--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -86,9 +86,11 @@ export default class TypeScriptCompiler extends SimpleCompilerBase {
   addHotModuleLoadingRegistration(sourceCode, fileName, exports) {
     if (exports.length < 1) return sourceCode;
 
-    let registrations = exports.map(x => 
-      `__REACT_HOT_LOADER__.register(${x}, "${x}", __FILENAME__);\n`
-    );
+    let registrations = exports.map(x => {
+      let id = `${x}` == 'default' ? "_default" : `${x}`
+      let name = `"${x}"`
+      return `__REACT_HOT_LOADER__.register(${id}, ${name}, __FILENAME__);\n`
+    });
 
     let tmpl = `
 ${sourceCode}


### PR DESCRIPTION
TL;DR

  * Don't use createProgram because
    * we've already read the file
    * we don't need dependents
  * Don't use TypeChecker because
    * undocumented `node.name.text` gives us exactly what `getSymbolAtLocation(node.name).getName()` gave us (as far as I can tell!)

Seen 966ms => 21ms and 661ms => 2ms reductions on a small project, see https://github.com/electron/electron-compile/issues/224#issuecomment-297523068