### PR TITLE
TypeScript then babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "rimraf": "^2.5.4",
     "sass-lookup": "^1.0.2",
     "sass.js": "^0.10.1",
+    "sorcery": "^0.10.0",
     "stylus": "^0.54.5",
     "stylus-lookup": "^1.0.1",
     "toutsuite": "^0.6.0",

--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -8,7 +8,7 @@ const d = require('debug')('electron-compile:typescript-compiler');
 let ts = null;
 let istanbul = null;
 
-const builtinKeys = ['hotModuleReload', 'coverage'];
+const builtinKeys = ['hotModuleReload', 'coverage', 'babel'];
 
 export default class TypeScriptCompiler extends SimpleCompilerBase {
   constructor() {
@@ -75,6 +75,16 @@ export default class TypeScriptCompiler extends SimpleCompilerBase {
     }
 
     d(JSON.stringify(output.diagnostics));
+
+    const babelOpts = this.parsedConfig.builtinOpts.babel;
+    if (babelOpts) {
+      if (!this.babel) {
+        const BabelCompiler = require("./babel").default;
+        this.babel = new BabelCompiler();
+        this.babel.compilerOptions = babelOpts;
+      }
+      return this.babel.compileSync(output.outputText, filePath);
+    }
 
     return {
       code: output.outputText,


### PR DESCRIPTION
The original idea is 100% pure @paulcbetts [tweetery](https://twitter.com/paulcbetts/status/847321051520311296), but I'm doing it for other selfish purposes.

Paul wanted to target a recent runtime (es2017?) with typescript and have babel fill in the gaps (with as few transformations as possible).

I'm just personally really pissed off at [native async/await stacktraces being completely broken](https://github.com/nodejs/node/issues/11865), so I wanted to go back to our previous strategy of turning async/await into Bluebird coroutines using babel.

Anyway, this pull request:

  * Accepts a new configuration key, `babel`, for the typescript compiler
  * Passes that config value (must be an object) wholesale, to the babel compiler (effectively what you'd put in your `.babelrc`, which electron-compilers ignores willingly afaict)
  * Makes babel compile typescript's output, and combines both sourcemaps with [sorcery](https://www.npmjs.com/package/sorcery)
  * Include the final sourcemap in the generated file, as an inline sourcemap

Note that this expects both typescript & babel to have (external) sourcemaps enabled.

I'm not sure it's mergeable as-is, but it's a start?!