### PR TITLE
support preloading babel plugins without standardized name

### DIFF
--- a/src/js/babel.js
+++ b/src/js/babel.js
@@ -19,6 +19,8 @@ export default class BabelCompiler extends SimpleCompilerBase {
   // installed in it. Instead, we try to load from our entry point's node_modules
   // directory (i.e. Grunt perhaps), and if it doesn't work, just keep going.
   attemptToPreload(names, prefix) {
+    if (!names.length) return null
+
     const fixupModule = (exp) => {
       // NB: Some plugins like transform-decorators-legacy, use import/export
       // semantics, and others don't
@@ -26,24 +28,49 @@ export default class BabelCompiler extends SimpleCompilerBase {
       return exp;
     };
 
-    const preloadStrategies = [
-      () => names.map((x) => fixupModule(require.main.require(`babel-${prefix}-${x}`))),
-      () => {
-        let nodeModulesAboveUs = path.resolve(__dirname, '..', '..', '..');
-        return names.map((x) => fixupModule(require(path.join(nodeModulesAboveUs, `babel-${prefix}-${x}`))));
-      },
-      () => names.map((x) => fixupModule(require(`babel-${prefix}-${x}`)))
-    ];
+    const nodeModulesAboveUs = path.resolve(__dirname, '..', '..', '..');
 
-    for (let strategy of preloadStrategies) {
-      try {
-        return strategy();
-      } catch (e) {
-        continue;
+    const preloadStrategies = [
+      x => fixupModule(require.main.require(x)),
+      x => fixupModule(require(path.join(nodeModulesAboveUs, x))),
+      x => fixupModule(require(x))
+    ]
+
+    const possibleNames = (name) => {
+      let names = [`babel-${prefix}-${name}`];
+
+      if (prefix === 'plugin') {
+        // Look for module names that do not start with "babel-plugin-"
+        names.push(name);
       }
+
+      return names;
+    };
+
+    // Apply one preloading strategy to the possible names of a module, and return the preloaded
+    // module if found, null otherwise
+    const preloadPossibleNames = (name, strategy) => {
+      if (typeof strategy !== 'function') return null;
+
+      return possibleNames(name).reduce((mod, possibleName)=>{
+        if (mod !== null) return mod;
+
+        try {
+          return strategy(possibleName);
+        } catch(e) {}
+
+        return null;
+      }, null)
     }
 
-    return null;
+    // Pick a loading strategy that finds the first plugin, the same strategy will be
+    // used to preload all plugins
+    const selectedStrategy = preloadStrategies.reduce((winner, strategy)=>{
+      if (winner !== null) return winner;
+      return preloadPossibleNames(names[0], strategy) === null ? null : strategy;
+    }, null)
+
+    return names.map(name => preloadPossibleNames(name, selectedStrategy)).filter((mod) => mod !== null)
   }
 
   compileSync(sourceCode, filePath, compilerContext) {


### PR DESCRIPTION
This patch add support for electron-compiler to preload babel plugins that do not use a standardized name as the the npm module name, for example [react-hot-loader](https://github.com/gaearon/react-hot-loader)

This indirectly helps to solve an [issue](https://github.com/electron/electron-compile/issues/213) when using electron-prebuilt-compile in an electron project and some npm dependencies  are `npm link`ed to a local "development package". When electron-compile can't preload a plugin defined in `.compilerc` babel-core ends up trying to locate all the plugins in the development package directory, and fails with an exception.
