### PR TITLE
Respect less includePaths if specified in .compilerc

### DIFF
--- a/src/css/less.js
+++ b/src/css/less.js
@@ -2,6 +2,7 @@ import path from 'path';
 import detective from 'detective-less';
 import {CompilerBase} from '../compiler-base';
 import toutSuite from 'toutsuite';
+import fs from 'fs';
 
 const mimeTypes = ['text/less'];
 let lessjs = null;
@@ -75,7 +76,15 @@ export default class LessCompiler extends CompilerBase {
     let dependencies = [];
 
     for (let dependencyName of dependencyFilenames) {
-      dependencies.push(path.join(path.dirname(filePath), dependencyName));
+      let paths = [
+        path.join(path.dirname(filePath), dependencyName)
+      ].concat((this.compilerOptions.paths || []).map(p => path.resolve(process.cwd(), p, dependencyName)))
+
+      let dependency = paths.find(p => fs.existsSync(p))
+
+      if (dependency) {
+        dependencies.push(dependency)
+      }
     }
 
     return dependencies;


### PR DESCRIPTION
I have a .less file, `/me/project/foo.less` that looks like this:

```less
@import (css, inline) 'ace-css/css/ace.css';
//... some other stuff
```

[`ace-css`](https://www.npmjs.com/package/ace-css) is present in the `node_modules` folder, so I configure `.compilerc` as so:

```javascript
{
  "env": {
    "development": {
      // ...
      "text/less": {
        "paths": [
          "./node_modules"
        ]
      // ...
```

The file is compiled and placed into the cache.  Problem is the `dependentFiles` field of the cache entry for `/me/project/foo.less` looks like this:

```javascript
{
// ...
  "dependentFiles": [
    "/me/project/ace-css/css/ace.css"
  ]
// ...
}
```

So the next time `/me/project/foo.less` is requested, everything explodes because `/me/project/ace-css/css/ace.css` does not exist.

The change in this PR is to look through the paths specified in the `.compilerc` file when working out the paths to dependent files before placing them into the cache.
