### PR TITLE
Add paths from 'includePaths' to Sass compiler

### DIFF
--- a/src/css/sass.js
+++ b/src/css/sass.js
@@ -49,6 +49,16 @@ export default class SassCompiler extends CompilerBase {
       paths.push(...this.compilerOptions.paths);
     }
 
+    // Add paths from option 'includePaths' in file .compilerc 
+    if (this.compilerOptions.includePaths) {
+      for (const includePath of this.compilerOptions.includePaths) {
+        paths.push(path.join(thisPath, includePath));
+      }
+      // NB. 'includePaths' is not a valid option for the sass compiler. 
+      // Remove 'includePaths' after it has served its purpose.
+      delete this.compilerOptions.includePaths;
+    }
+
     paths.unshift('.');
 
     sass.importer(this.buildImporterCallback(paths));


### PR DESCRIPTION
I've seen and encountered some issues regarding imports in Sass files. The proposed changes fixed the issues for me.

I use the property `includePaths` in `.compilerc` which is read by `sass.js`. The property `includePaths` is added to `this.compilerOptions` but is not a valid option for the compiler. So, after reading the property and adding the paths to be included to `paths`, I discard it before is gets passed to sass.compiler.

I've tested the changes in a standard project created by `electron-forge init` and added a few stylesheets containing imports (e.g. bootstap scss files).

The includePaths is added to `.compilerc` like:
```{
  "env": {
    "development": {
      "text/scss": {
        "includePaths": ["../../node_modules/bootstrap/scss"]
      },
      ...
```
The includePaths are relative to the stylesheet being compiled.
