### PR TITLE
Use the full path, rather than the basename, when calling sassLookup.

### DIFF
--- a/src/css/sass.js
+++ b/src/css/sass.js
@@ -95,7 +95,7 @@ export default class SassCompiler extends CompilerBase {
     let dependencies = [];
 
     for (let dependencyName of dependencyFilenames) {
-      dependencies.push(sassLookup(dependencyName, path.basename(filePath), path.dirname(filePath)));
+      dependencies.push(sassLookup(dependencyName, filePath, path.dirname(filePath)));
     }
 
     return dependencies;


### PR DESCRIPTION
This allows files partials (or files that begin with an underscore, but can be loaded without them) dependencies to resolve correctly (and work on subsequent loads).

sass-lookup expects a full path, but also doesn't check `directory` for the underscored path.

Fixes https://github.com/electron/electron-compile/issues/255