### PR TITLE
Disable compiling of sass partials.

### DIFF
--- a/src/css/sass.js
+++ b/src/css/sass.js
@@ -30,7 +30,8 @@ export default class SassCompiler extends CompilerBase {
   }
 
   async shouldCompileFile(fileName, compilerContext) {
-    return true;
+    let basename = path.basename(fileName);
+    return basename[0] != "_";
   }
 
   async determineDependentFiles(sourceCode, filePath, compilerContext) {
@@ -87,7 +88,8 @@ export default class SassCompiler extends CompilerBase {
   }
 
   shouldCompileFileSync(fileName, compilerContext) {
-    return true;
+    let basename = path.basename(fileName);
+    return basename[0] != "_";
   }
 
   determineDependentFilesSync(sourceCode, filePath, compilerContext) {


### PR DESCRIPTION
Attempting to compile SASS partials often creates errors. They should not be compiled individually.

Combined with https://github.com/electron/electron-compile/pull/260, should fix https://github.com/electron-userland/electron-forge/issues/182