### PR TITLE
Use coffeescript, not coffee-script

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-preset-env": "^1.3.2",
     "btoa": "^1.1.2",
     "cheerio": "^0.20.0",
-    "coffee-script": "^1.10.0",
+    "coffeescript": "^1.10.0",
     "cson": "^3.0.2",
     "debug": "^2.5.1",
     "detective-less": "^1.0.0",

--- a/src/js/coffeescript.js
+++ b/src/js/coffeescript.js
@@ -19,7 +19,7 @@ export default class CoffeeScriptCompiler extends SimpleCompilerBase {
   }
 
   compileSync(sourceCode, filePath) {
-    coffee = coffee || require('coffee-script');
+    coffee = coffee || require('coffeescript');
 
     let {js, v3SourceMap} = coffee.compile(
       sourceCode,
@@ -44,6 +44,6 @@ export default class CoffeeScriptCompiler extends SimpleCompilerBase {
   }
 
   getCompilerVersion() {
-    return require('coffee-script/package.json').version;
+    return require('coffeescript/package.json').version;
   }
 }


### PR DESCRIPTION
Avoids the following warning:

> `npm WARN deprecated coffee-script@1.12.7: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)`