### PR TITLE
feature: load options from tsconfig.json

### DIFF
--- a/src/js/typescript.js
+++ b/src/js/typescript.js
@@ -1,4 +1,5 @@
 import {SimpleCompilerBase} from '../compiler-base';
+import fs from 'fs';
 import path from 'path';
 import jsEscape from 'js-string-escape';
 
@@ -17,9 +18,19 @@ export default class TypeScriptCompiler extends SimpleCompilerBase {
 
     this.outMimeType = 'application/javascript';
     this.compilerOptions = {
+      ...TypeScriptCompiler.getTSConfigOptions(),
       inlineSourceMap: true,
       inlineSources: true
     };
+  }
+
+  static getTSConfigOptions() {
+    const configFile = path.join(process.cwd(), 'tsconfig.json');
+    if (fs.existsSync(configFile)) {
+      return require(configFile).compilerOptions;
+    } else {
+      return {};
+    }
   }
 
   static getInputMimeTypes() {


### PR DESCRIPTION
This is related to issues found here:

https://github.com/electron-userland/electron-compilers/issues/88

I can't find where electron-compilers actually loads options from the project's tsconfig.json