### PR TITLE
Added EJS compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ For CSS:
 For HTML:
 
 * Jade
+* EJS
 
 For JSON:
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "detective-sass": "^2.0.0",
     "detective-scss": "^1.0.0",
     "detective-stylus": "^1.0.0",
+    "ejs": "^2.5.8",
     "graphql": "^0.9.3",
     "graphql-tag": "^2.0.0",
     "istanbul": "^0.4.5",

--- a/src/html/ejs.js
+++ b/src/html/ejs.js
@@ -1,0 +1,51 @@
+import {SimpleCompilerBase} from '../compiler-base';
+
+// It should be noted that this compiler may not be perfect when it comes to
+// caching, due to the ability of ejs to include other files, at least at this 
+// time (first created)
+
+const inputMimeTypes = ['text/ejs'];
+let ejs = null;
+
+/**
+ * @access private
+ */ 
+export default class EjsCompiler extends SimpleCompilerBase {
+  constructor() {
+    super();
+
+    // This is here in case the user/developer has access to the compiler
+    // Those using ejs with electron may already be assuming they can
+    // access/provide the data object to pass in to the renderer.
+    this.data = {};
+  }
+
+  static getInputMimeTypes() {
+    return inputMimeTypes;
+  }
+
+  compileSync(sourceCode, filePath) {
+    ejs = ejs || require('ejs');
+
+    let code = ejs.render(
+      sourceCode,
+      this.data,
+      Object.assign({ filename: filePath, cache: false }, this.compilerOptions));
+
+    return { code, mimeType: 'text/html' };
+  }
+  
+  getCompilerVersion() {
+    return require('ejs/package.json').version;
+  }
+
+  // Users of ejs will likely be more familiar with the 'options' key
+  // This is here in case the user/developer has access to the compiler
+  get options() {
+    return this.compilerOptions;
+  }
+
+  set options(newOptions) {
+    this.compilerOptions = newOptions;
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ const filenames = [
   'js/coffeescript',
   'js/typescript',
   'json/cson',
+  'html/ejs',
   'html/inline-html',
   'html/jade',
   'html/vue',


### PR DESCRIPTION
Hi,

This PR adds support for `.ejs` files to `electron-compilers`.

Used the GraphQL PR as a reference for what files to change.

Used the JadeCompiler as a starting template for this compiler, as their syntax for loading files looked very similar. However, I was not familiar with the `sourceMap` usage, so I removed it, however it can be added back in if needed.

Since ejs allows you to pass in data, and those familiar with other ejs electron packages are used to being able to provide data and options, I added this to the compiler. I'm not quite sure the best way to make it possible however. One way seemed to access `globalCompilerHost.compilersByMimeType.ejs.data`, but I would appreciate any feedback or thoughts on this.

I'm also not sure how it will handle caching, as ejs files are able to `include()` other ejs files.